### PR TITLE
feat(app): allow to search for multiple product names

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,19 @@ eurotronic-trv-valvepos:
   module: eurotronic-trv-valvepos
   class: EurotronicTRVValvePos
   ozw_log_path: "/config/OZW_Log.txt"
-  look_for_productname: "EUR_SPIRITZ Wall Radiator Thermostat"
+  look_for_productname:
+    - "EUR_SPIRITZ Wall Radiator Thermostat"
+    - "ZWA021 Thermostatic Valve"
   refresh_seconds: 300
 ```
 
 Key | Required | Type | Default | Description
 -- | -- | -- | -- | --
-`module` | True | string | | Module name, should be `eurotronic-trv-valvepos`
-`class` | True | string | | App class name, should be `EurotronicTRVValvePos`
-`ozw_log_path` | False | string | `/config/OZW_Log.txt` | Path to OZW log file, default works in [Hass.io](https://www.home-assistant.io/hassio/)
-`look_for_productname` | False | string | `EUR_SPIRITZ Wall Radiator Thermostat` | Z-Wave product name to look for when searching for TRV Z-Wave device entities, default works for SPIRIT Z-Wave Plus TRV
-`refresh_seconds` | False | integer | 300 | Seconds between log scans
+`module` | True | `string` | | Module name, should be `eurotronic-trv-valvepos`
+`class` | True | `string` | | App class name, should be `EurotronicTRVValvePos`
+`ozw_log_path` | False | `string` | `/config/OZW_Log.txt` | Path to OZW log file, default works in [Hass.io](https://www.home-assistant.io/hassio/)
+`look_for_productname` | False | `string | [string]` | `EUR_SPIRITZ Wall Radiator Thermostat` | Z-Wave product names to look for when searching for TRV Z-Wave device entities, default works for SPIRIT Z-Wave Plus TRV
+`refresh_seconds` | False | `integer` | 300 | Seconds between log scans
 
 ## Troubleshooting
 

--- a/apps/eurotronic-trv-valvepos/eurotronic-trv-valvepos.py
+++ b/apps/eurotronic-trv-valvepos/eurotronic-trv-valvepos.py
@@ -30,7 +30,7 @@ class EurotronicTRVValvePos(hass.Hass):
 
                 # iterate over zwave domain entities, look for specific "product_name" attribute value
                 # that value indicates that the entity is Z-Wave device entity for EUROTRONIC TRV
-                if (v["attributes"]["product_name"] == self.args.get("look_for_productname", "EUR_SPIRITZ Wall Radiator Thermostat")):
+                if (v["attributes"]["product_name"] in self.args.get("look_for_productname", ["EUR_SPIRITZ Wall Radiator Thermostat"])):
                     node_id = v["attributes"]["node_id"]
                     self.log("Processing Z-Wave node ID " + str(node_id), level = "DEBUG")
 


### PR DESCRIPTION
Allow to configure multiple product names for the app to use when searching logs. This feature is backwards compatible.

closes #4